### PR TITLE
Make cabal v1-install go

### DIFF
--- a/README
+++ b/README
@@ -18,8 +18,8 @@ QuickCheck library; others use the LeanCheck library.  If these are not
 included in your Haskell installation you may be able to add them using the
 Cabal tool, like this:
 $ cabal update
-$ cabal v1-install quickcheck --lib
-$ cabal v1-install leancheck --lib
+$ cabal v1-install QuickCheck
+$ cabal v1-install leancheck
 
 4. A Makefile specifies how to build the simplifier and how to obtain test
 data and measured test results, filed in subdirectories.  So check that you


### PR DESCRIPTION
I suppose --lib used to be something to only install the library version ?

Currently it errors with:
```
cabal: option `--lib' is ambiguous; could be one of:
--libdir=DIR installation directory for libraries
--libsubdir=DIR subdirectory of libdir in which libs are
installed
--libexecdir=DIR installation directory for program executables
--libexecsubdir=DIR subdirectory of libexecdir in which private
executables are installed
--library-profiling-detail=level
Profiling detail level for libraries only.
```

Installs without --lib as well. Seems to work fine with `make testdata`